### PR TITLE
Adds some Dockerfile best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
 FROM ubuntu:trusty
-MAINTAINER vranac<vranac@gmai.com>
+MAINTAINER vranac<vranac@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-RUN apt-get install -qy python python-gpgme
+RUN apt-get update && apt-get install -qy --no-install-recommends \
+    ca-certificates \
+    python \
+    python-gpgme \
+    wget
 
-ADD https://www.dropbox.com/download?plat=lnx.x86_64 /root/dropbox.tgz
-ADD https://www.dropbox.com/download?dl=packages/dropbox.py /root/dropbox.py
-RUN chmod a+x /root/dropbox.py
+RUN set -x \
+    && wget --quiet https://www.dropbox.com/download?plat=lnx.x86_64 -O /root/dropbox.tgz \
+    && wget --quiet https://www.dropbox.com/download?dl=packages/dropbox.py -O /root/dropbox.py \
+    && chmod a+x /root/dropbox.py \
+    && cd root \
+    && tar xfz dropbox.tgz \
+    && rm dropbox.tgz 2> /dev/null
 
-RUN cd root && tar xfvz dropbox.tgz && rm dropbox.tgz
+CMD ["/root/.dropbox-dist/dropboxd"]
 
-CMD /root/.dropbox-dist/dropboxd


### PR DESCRIPTION
As promised.
- fixes email :)
- apt-get update needs to be in the same layer as the install
  otherwise the apt-get update line will never get invalidated
  and will always use the cached value, which will fail after some
  time when the cache becomes invalid.
- adds --no-install-recommends to install less stuff (smaller images)
- install packages in alphabetical order (better git diff)
- Removes ADD for explicit wget. This has the benefit of not
  invalidating the cache on every rebuild. Docker cache is good.
  We should use more of it. ADD is only used for setting the rootfs
  anyway. If you have a local file in the docker context then use
  COPY. But make sure to put it at the end if possible. COPY will
  not invalidate the cache everytime is the file being added has not
  changed.
- Adds CMD exec mode so we don't spawn bash as PID 1. So we make suere
  the actual dropboxd process the only process in the container.
  This is the correct thing to do because of signal handling. Bash
  wont really respond and you do want your actual process to get the
  signal forwarded from the user -> docker daemon -> process.
  This might not be needed since the daemon doesn't handle signals
  really well though. :D

More info here:
https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/

NOTES: perhaps  you should consider using the official python:2.7 (or 2.7-slim) rather than installing python in the ubuntu image. Also adding a Makefile that abstracts away the docker commands might make it more easier to user (ie. make build, make pull, make run). 
